### PR TITLE
Upgrade Gradle & Update Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,23 +11,21 @@ version = "3.1.1"
 val targetJavaVersion = 8
 
 // Dependencies
-
 repositories {
     mavenCentral()
-
     maven("https://hub.spigotmc.org/nexus/content/groups/public/")
     maven("https://repo.dmulloy2.net/repository/public/")
 }
 
 dependencies {
-    compileOnly("org.bukkit:bukkit:1.9.4-R0.1-SNAPSHOT")
-    compileOnly("io.netty:netty-all:4.1.79.Final")
+    compileOnly("org.spigotmc:spigot-api:1.9.4-R0.1-SNAPSHOT")
+    compileOnly("io.netty:netty-all:4.1.86.Final")
 
     compileOnly("com.comphenix.protocol:ProtocolLib:4.7.0")
     compileOnly("net.luckperms:api:5.4")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 
 // Set java version

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Build and changes have been tested and are working.

# Changes
- Change `org.bukkit:bukkit` to `org.spigotmc:spigot-api` (`org.bukkit:bukkit` isn't published anymore)
- Upgrade `Gradle` to version `8.1`
- Update `netty-all` to version `4.1.86.Final`
- Update `junit-jupiter-api` to version `5.9.2`
- Update `junit-jupiter-engine` to version `5.9.2`